### PR TITLE
Resolve write error when using multiple fields

### DIFF
--- a/src/main/scala/io/waylay/influxdb/WriteProtocol.scala
+++ b/src/main/scala/io/waylay/influxdb/WriteProtocol.scala
@@ -44,10 +44,10 @@ private[influxdb] object WriteProtocol extends SharedProtocol{
           case IBoolean(value) => value.toString
           case IString(value) => escapeValue(value)
         }
-        " " + escapeTag(key) + "=" + stringValue
+        escapeTag(key) + "=" + stringValue
       }.mkString(",")
       val timestamp = applyPrecision(point.timestamp)
-      s"""$measurementName$tags$fields $timestamp"""
+      s"""$measurementName$tags $fields $timestamp"""
     }
     lines.mkString("\n")
   }

--- a/src/test/scala/io/waylay/influxdb/WriteProtocolSpec.scala
+++ b/src/test/scala/io/waylay/influxdb/WriteProtocolSpec.scala
@@ -98,5 +98,18 @@ class WriteProtocolSpec extends Specification {
           |temp,tag=test value="high" 2000""".stripMargin
     }
 
+    "handle multiple fields" in {
+      val myValue = 21d
+
+      val dataLine = WriteProtocol.write(TimeUnit.MILLISECONDS,
+        IPoint("temp", Seq("resource" -> "test"),
+          Seq("value1" -> IString("foo bar"), "value2" -> IInteger(21), "value3" -> IFloat(myValue)),
+          Instant.ofEpochSecond(1)
+        )
+      )
+
+      dataLine must be equalTo """temp,resource=test value1="foo bar",value2=21i,value3=21.0 1000"""
+    }
+
   }
 }


### PR DESCRIPTION
When writing multiple fields I got an error:

`"error":"unable to parse 'temperature,device=tadocelsius=20.260000228881836,humidity=31.799999237060547,heatingPower=0.0 1518526376387': invalid tag format"`

There is a blank missing between the tags and the fields. Fixed it locally and seems to work now. Also provided a test case.