### PR TITLE
chore: allow scala-parser-combinators eviction for sbt 1.12.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,11 @@ releaseCrossBuild := true
 
 ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-java8-compat"       % VersionScheme.Always,
+  "org.scala-lang.modules" %% "scala-parser-combinators" % VersionScheme.Always
+)
+
 // we need both Test and IntegrationTest scopes for a correct pom, see https://github.com/sbt/sbt/issues/1380
 val TestAndIntegrationTest = IntegrationTest.name + "," + Test.name
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.10


### PR DESCRIPTION
Replaces https://github.com/waylayio/influxdb-scala/pull/293